### PR TITLE
blueprint: Use Infrastructure constructor

### DIFF
--- a/nginxExampleWithInfra.js
+++ b/nginxExampleWithInfra.js
@@ -1,7 +1,5 @@
 const nginx = require('./nginx');
-const { Machine, createDeployment } = require('kelda');
-
-const deployment = createDeployment();
+const { Infrastructure, Machine } = require('kelda');
 
 // Setup the infrastructure.
 const baseMachine = new Machine({
@@ -13,7 +11,6 @@ const baseMachine = new Machine({
 });
 
 // Create Master and Worker Machines.
-deployment.deploy(baseMachine.asMaster());
-deployment.deploy(baseMachine.asWorker().replicate(1));
+const infra = new Infrastructure(baseMachine, baseMachine);
 
-nginx.createContainer().deploy(deployment);
+nginx.createContainer().deploy(infra);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "./nginx.js",
   "license": "MIT",
   "dependencies": {
-    "kelda": "0.x"
+    "kelda": ">=0.0.5 <1.0.0"
   },
   "devDependencies": {
     "eslint": "^4.4.1",


### PR DESCRIPTION
This commit replaces the deprecated `createDeployment` function with the
new `Infrastructure` constructor.