### PR TITLE
blueprint: Make hostname compliant with the Kubernetes spec

### DIFF
--- a/nginx.js
+++ b/nginx.js
@@ -53,7 +53,7 @@ exports.createContainer = function createContainer(port = 80) {
   files[path.join(siteSourceDirectory, indexFilename)] = indexFileData;
 
   // Create a Nginx Docker container.
-  const webTier = new Container('web_tier', image, {
+  const webTier = new Container('web-tier', image, {
     filepathToContent: files,
   });
   allowTraffic(publicInternet, webTier, port);


### PR DESCRIPTION
Kubernetes hostnames (which follows
https://www.ietf.org/rfc/rfc1123.txt) do not allow underscores.