### PR TITLE
blueprint: Use new constructor format

### DIFF
--- a/nginx.js
+++ b/nginx.js
@@ -53,7 +53,9 @@ exports.createContainer = function createContainer(port = 80) {
   files[path.join(siteSourceDirectory, indexFilename)] = indexFileData;
 
   // Create a Nginx Docker container.
-  const webTier = new Container('web-tier', image, {
+  const webTier = new Container({
+    name: 'web-tier',
+    image,
     filepathToContent: files,
   });
   allowTraffic(publicInternet, webTier, port);

--- a/nginxExampleWithInfra.js
+++ b/nginxExampleWithInfra.js
@@ -11,6 +11,9 @@ const baseMachine = new Machine({
 });
 
 // Create Master and Worker Machines.
-const infra = new Infrastructure(baseMachine, baseMachine);
+const infra = new Infrastructure({
+  masters: baseMachine,
+  workers: baseMachine,
+});
 
 nginx.createContainer().deploy(infra);


### PR DESCRIPTION
The build will fail until the next release of Kelda (0.10.0). This should not be merged until then.